### PR TITLE
Config example(s) extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ If you want to add the authenticated user to your http header, load the followin
 Sample Config
 =============
 
+    # make sure the header is only written in the auth location
+    RequestHeader unset X_ISRW_PROXY_AUTH_USER
     <Location /authenticate >
         #AllowOverride None
         AuthName "Private location"

--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -282,6 +282,8 @@ SSLRandomSeed connect builtin
 	ProxyPass /ror_auth http://127.0.0.1:3101/ror 
 	ProxyPassReverse /ror_auth http://127.0.0.1:3101/ror 
 
+        # make sure the header is only written in the auth location
+        RequestHeader unset X_ISRW_PROXY_AUTH_USER
 	<Location /ror_auth >
 	#Order allow,deny
 	#Allow from all


### PR DESCRIPTION
Header containing the authenticated username must be unset always and only set in the Location that is configured for ntlm auth.