### PR TITLE
cmake Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,50 @@
+#
+# -- CMAKE build file for mod_auth_ntlm
+#
 cmake_minimum_required (VERSION 3.9.1)
-
 project(mod_authn_ntlm C)
-
 set(LIBAPR "libapr-1")
 set(LIBAPRUTIL "libaprutil-1")
 
-if (MSVC)
-	if(CMAKE_BUILD_TYPE MATCHES Debug)
-		add_definitions(/MTd)
-	else()
-		add_definitions(/MT)
-	endif()
+if(NOT DEFINED APACHE_ROOT)
+set(APACHE_ROOT "Apache24")
+endif()
+option( USE_STATIC_RUNTIME "use MSVC static runtimes" OFF)
+#
+# -- Windows option for static runtimes - must match Apache build
+#    default is OFF and will use /MD /MDd, whcih links against VC runtime dlls.
+#    USE_STATIC_RUNTIME uses /MT or /MTd, no VC dlls needed
+#    
+if(DEFINED USE_STATIC_RUNTIME AND USE_STATIC_RUNTIME AND WIN32)
+   # Set MSVC runtime flags for all configurations
+    foreach(cfg "" ${CMAKE_CONFIGURATION_TYPES})
+        set(flag_var CMAKE_CXX_FLAGS)
+        if(cfg)
+            string(TOUPPER ${cfg} cfg_upper)
+            string(APPEND flag_var "_${cfg_upper}")
+        endif()
+        if(${flag_var} MATCHES "/MD")
+            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+        endif()
+        set(flag_var CMAKE_C_FLAGS)
+        if(cfg)
+            string(TOUPPER ${cfg} cfg_upper)
+            string(APPEND flag_var "_${cfg_upper}")
+        endif()
+        if(${flag_var} MATCHES "/MD")
+            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+        endif()
+    endforeach()
 endif()
 
-include_directories(Apache24/include)
-LINK_DIRECTORIES(Apache24/lib)
-
-
+include_directories(${APACHE_ROOT}/include)
+link_directories(${APACHE_ROOT}/lib)
 
 file(GLOB_RECURSE SOURCE_FILES
-
     "src/*.h"
-
     "src/*.c"
-
 )
 
-
-
 add_library(mod_authn_ntlm SHARED ${SOURCE_FILES})
+set_target_properties(mod_authn_ntlm PROPERTIES SUFFIX ".so")
 target_link_libraries(mod_authn_ntlm libhttpd ${LIBAPR} ${LIBAPRUTIL})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,3 +48,9 @@ file(GLOB_RECURSE SOURCE_FILES
 add_library(mod_authn_ntlm SHARED ${SOURCE_FILES})
 set_target_properties(mod_authn_ntlm PROPERTIES SUFFIX ".so")
 target_link_libraries(mod_authn_ntlm libhttpd ${LIBAPR} ${LIBAPRUTIL})
+
+install(TARGETS mod_authn_ntlm
+        CONFIGURATIONS Release
+        CONFIGURATIONS Debug
+        RUNTIME DESTINATION ${APACHE_ROOT}/modules
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 option( USE_STATIC_RUNTIME "use MSVC static runtimes" OFF)
 #
 # -- Windows option for static runtimes - must match Apache build
-#    default is OFF and will use /MD /MDd, whcih links against VC runtime dlls.
+#    default is OFF and will use /MD /MDd, which links against VC runtime dlls.
 #    USE_STATIC_RUNTIME uses /MT or /MTd, no VC dlls needed
 #    
 if(DEFINED USE_STATIC_RUNTIME AND USE_STATIC_RUNTIME AND WIN32)

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Build instructions
 
 **cmake options:**
 
-    -USER_STATIC_RUNTIME (default is OFF) and will use /MD and /MDd if on will build with /MT and /MTd for release and debug, respectively
-    -APACHE_ROOT default is the local folder if not set. Otherwise set to the location of your apache instalation such as C:\Program Files\Apache24
+- USE_STATIC_RUNTIME (default is OFF) and will use /MD and /MDd if on will build with /MT and /MTd for release and debug, respectively
+- APACHE_ROOT default is the local folder if not set. Otherwise set to the location of your apache instalation such as C:\Program Files\Apache24
 
 **examples for Visual Studio:**
 

--- a/README.md
+++ b/README.md
@@ -113,25 +113,27 @@ Build instructions
 
 - Install the latest CMake from https://cmake.org/download/
 - Download Win64 Apache 2.4 from https://www.apachelounge.com/download/ (or use your own version)
-- Extract it to this folder (so there is a folder called Apache24 inside this folder)
+- note build options should match Apache build (architecture, variant, and runtime linking)
 
-**Open command prompt:**
+**cmake options:**
+    -USER_STATIC_RUNTIME (default is OFF) and will use /MD and /MDd if on will build with /MT and /MTd for release and debug, respectively
+    -APACHE_ROOT default is the local folder if not set. Otherwise set to the location of your apache instalation such as C:\Program Files\Apache24
 
-`mkdir build`
+**examples for Visual Studio:**
 
-`cd build`
+`cd mod_auth_ntlm`
+`cmake -B ./build-x64 -S ./ -G "Visual Studio 15 2017" -A x64 -T host=x64 -DAPACHE_ROOT="C:\Program Files\Apache24"`
+`cmake --build ./build-x64 --config Release`
+`cmake --build ./build-x64 --config Debug`
+static runtimes
+`cmake -B ./build-s-x64 -S ./ -G "Visual Studio 15 2017" -A x64 -T host=x64 -DAPACHE_ROOT="C:\Program Files\Apache24" -DUSE_STATIC_RUNTIME=ON`
+`cmake --build ./build-s-x64 --config Release`
+`cmake --build ./build-s-x64 --config Debug`
 
-`cmake -G "YOUR_GENERATOR" ..`
+**install mod_auth_ntlm.so to module path**
 
----
-
-Open solution found in build folder
-Build solution for **Debug** and **Release**
-Find the build output at: `build\debug` or `build\release`
-
-> You may have to rename the `.dll` to a `.so`
-
----
+`cmake -DBUILD_TYPE=Release -P ./build-x64/cmake_install.cmake`
+ 
 
 Example Generators
 ==================

--- a/README.md
+++ b/README.md
@@ -116,18 +116,26 @@ Build instructions
 - note build options should match Apache build (architecture, variant, and runtime linking)
 
 **cmake options:**
+
     -USER_STATIC_RUNTIME (default is OFF) and will use /MD and /MDd if on will build with /MT and /MTd for release and debug, respectively
     -APACHE_ROOT default is the local folder if not set. Otherwise set to the location of your apache instalation such as C:\Program Files\Apache24
 
 **examples for Visual Studio:**
 
 `cd mod_auth_ntlm`
+
 `cmake -B ./build-x64 -S ./ -G "Visual Studio 15 2017" -A x64 -T host=x64 -DAPACHE_ROOT="C:\Program Files\Apache24"`
+
 `cmake --build ./build-x64 --config Release`
+
 `cmake --build ./build-x64 --config Debug`
+
 static runtimes
+
 `cmake -B ./build-s-x64 -S ./ -G "Visual Studio 15 2017" -A x64 -T host=x64 -DAPACHE_ROOT="C:\Program Files\Apache24" -DUSE_STATIC_RUNTIME=ON`
+
 `cmake --build ./build-s-x64 --config Release`
+
 `cmake --build ./build-s-x64 --config Debug`
 
 **install mod_auth_ntlm.so to module path**

--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ Build instructions
 
 - Install the latest CMake from https://cmake.org/download/
 - Download Win64 Apache 2.4 from https://www.apachelounge.com/download/ (or use your own version)
-- note build options should match Apache build (architecture, variant, and runtime linking)
+- Build options should match Apache build (architecture, variant, and runtime linking)
 
 **cmake options:**
 
 - USE_STATIC_RUNTIME (default is OFF) and will use /MD and /MDd. If ON will build with /MT and /MTd for release and debug, respectively.
-- APACHE_ROOT default is the local folder if not set. Otherwise set to the location of your apache instalation such as C:\Program Files\Apache24.
+- APACHE_ROOT default is the local folder if not set. Otherwise set to the location of your apache installation such as C:\Program Files\Apache24.
 
 **examples for Visual Studio:**
 

--- a/src/mod_ntlm_interface.c
+++ b/src/mod_ntlm_interface.c
@@ -288,18 +288,17 @@ int get_sspi_header(sspi_auth_ctx *ctx)
 	 * and we're authoritative, reply 401 again */
 	scheme = ap_getword_white(ctx->r->pool, &auth_line);
 
-	if (ctx->crec->sspi_offerbasic &&
-		0 == lstrcmpi(scheme, "Basic")) {
+	
+	if (ctx->crec->sspi_offerbasic && 0 == lstrcmpi(scheme, "Basic")) {
 		ctx->scr->package = ctx->crec->sspi_package_basic;
 		ret = get_basic_userpass(ctx, auth_line);
 		sspi_set_domain(ctx);
 		sspi_set_default_domain(ctx);
 		return ret;
-	} else if (ctx->crec->sspi_offersspi &&
-		   0 == check_package_valid(ctx, scheme)) {
+	} else if (ctx->crec->sspi_offersspi && 0 == check_package_valid(ctx, scheme)) {
 		if (0 == ctx->scr->package)
-			ctx->scr->package =
-				apr_pstrdup(ctx->r->connection->pool, scheme);
+			ctx->scr->package = apr_pstrdup(ctx->r->connection->pool, scheme);
+
 		return get_sspi_userpass(ctx, auth_line);
 	}
 


### PR DESCRIPTION
Several improvements to building with cmake are included: changed .dll to .so, added install target, added static runtime option, added ability to specify apache root folder.